### PR TITLE
Set up flake-based Wayland Sway configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Wayland-first NixOS configuration with Sway";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+    in
+    {
+      nixosConfigurations.nixos-wayland = nixpkgs.lib.nixosSystem {
+        inherit system;
+        specialArgs = { inherit pkgs; };
+        modules = [
+          ./configuration.nix
+        ];
+      };
+
+      formatter.${system} = pkgs.alejandra;
+    };
+}


### PR DESCRIPTION
## Summary
- add flake-based entrypoint for the NixOS configuration
- simplify the system configuration around a Wayland/Sway setup with printing, audio, and zsh
- enable nix-ld for IntelliJ and other binaries while keeping the base packages lean

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ba43de5b483269bbb298a4d69912b)