### PR TITLE
Add `codex` CLI to home-manager packages

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -47,6 +47,7 @@
     wdisplays # screen management for wayland
     cliphist
     ripgrep
+    codex
   ];
 
   home.sessionVariables = {


### PR DESCRIPTION
### Motivation

- Enable the Codex CLI to be installed and available in the home-manager user environment.
- Make `codex` available on the user's PATH alongside other declared `home.packages`.

### Description

- Add `codex` to the `home.packages` list in `home/home.nix`.
- No other configuration changes were made.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7c51b934832685b47444b4faaf83)