### PR TITLE
feat: disable zsh variable completion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,4 +3,4 @@
 [x] ~~Erzeuge eine Liste aller configurierten Sway Shortcuts und erzeuge die Markdown Datei /shortcuts.md. Die Datei soll auch das aktuelle datum enthalten. Bitte interpretiere die kommandos und erklaere sie~~
 [x] ~~Erzeuge mir die Shortcuts aber bitte die Kommandos nicht auflisten~~
 [x] ~~install calibre~~
-[ ] zsh: tab completion schlaegt mir immer Variablen vor. das will ich nicht. schalt das ab.
+[x] ~~zsh: tab completion schlaegt mir immer Variablen vor. das will ich nicht. schalt das ab.~~

--- a/home/zsh.nix
+++ b/home/zsh.nix
@@ -3,6 +3,10 @@
   programs.zsh = {
     enable = true;
     enableCompletion = true;
+    completionInit = ''
+      zstyle ':completion:*' tag-order '!parameters'
+      autoload -U compinit && compinit
+    '';
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;
     shellAliases = {


### PR DESCRIPTION
TODO: zsh: tab completion schlaegt mir immer Variablen vor. das will ich nicht. schalt das ab.

Problem/Aufgabe:
Tab-Completion schlaegt Variablen/Parameter vor.

Loesung/Aenderungen:
Zsh-Completion konfiguriert, damit der parameters-Tag nicht angeboten wird.

Hinweise fuer manuelle Tests:
Tab-Completion nutzen und pruefen, dass keine Parameter/Variablen vorgeschlagen werden.
