### PR TITLE
codex/issue-14-remove-calibre

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -17,7 +17,6 @@
     thunderbird
     google-chrome
     jetbrains.idea
-    calibre
     freecad
     gimp
     go


### PR DESCRIPTION
## Was geändert wurde
- `calibre` aus `home.packages` entfernt

## Verifikation
- Nicht ausgeführt (nicht angefragt)

## Risiko-Hinweise
- Keine

## flake.lock
- Unverändert