### PR TITLE
codex/issue-14-calibre-deinstall

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -17,7 +17,6 @@
     thunderbird
     google-chrome
     jetbrains.idea
-    calibre
     freecad
     gimp
     go


### PR DESCRIPTION
## Summary
- remove calibre from home-manager package list

## Verification
- make fmt
- make check
- make dry-build

## Notes
- No lockfile changes
- No system-critical areas touched