### PR TITLE
codex/issue-21-battery-notify

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -127,6 +127,14 @@
       #jack.enable = true;
 
     };
+    upower = {
+      enable = true;
+      usePercentageForPolicy = true;
+      percentageLow = 10;
+      percentageCritical = 5;
+      percentageAction = 3;
+      criticalPowerAction = "PowerOff";
+    };
     k3s = {
       enable = true;
       role = "server";

--- a/home/home.nix
+++ b/home/home.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 {
   nixpkgs.config.allowUnfree = true;
@@ -47,6 +47,7 @@
     wdisplays # screen management for wayland
     cliphist
     ripgrep
+    libnotify
     codex
   ];
 
@@ -88,6 +89,23 @@
         "-max-dedupe-search"
         "50"
       ];
+    };
+  };
+
+  systemd.user.services.battery-notify = {
+    Unit = {
+      Description = "Battery low notification";
+      PartOf = [ "sway-session.target" ];
+      After = [ "sway-session.target" ];
+    };
+    Service = {
+      ExecStart = "${config.home.homeDirectory}/.local/scripts/bin/battery-notify.sh";
+      Environment = "PATH=${lib.makeBinPath [ pkgs.bash pkgs.coreutils pkgs.gawk pkgs.ripgrep pkgs.upower pkgs.libnotify ]}";
+      Restart = "always";
+      RestartSec = 10;
+    };
+    Install = {
+      WantedBy = [ "sway-session.target" ];
     };
   };
 }

--- a/home/shell-scripts/battery-notify.sh
+++ b/home/shell-scripts/battery-notify.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_dir="${XDG_CACHE_HOME:-"$HOME/.cache"}"
+state_file="${cache_dir}/battery-notify.state"
+
+mkdir -p "${cache_dir}"
+
+get_battery_device() {
+  upower -e | rg -m1 battery || true
+}
+
+get_battery_info() {
+  local device="${1}"
+  upower -i "${device}"
+}
+
+while true; do
+  device="$(get_battery_device)"
+  if [[ -z "${device}" ]]; then
+    sleep 60
+    continue
+  fi
+
+  info="$(get_battery_info "${device}")"
+  state="$(printf '%s\n' "${info}" | rg "^\\s*state:" | awk '{print $2}')"
+  percentage_raw="$(printf '%s\n' "${info}" | rg "^\\s*percentage:" | awk '{print $2}')"
+  percentage="${percentage_raw%%%}"
+
+  if [[ "${state}" != "discharging" ]]; then
+    rm -f "${state_file}"
+    sleep 60
+    continue
+  fi
+
+  last_state=""
+  if [[ -f "${state_file}" ]]; then
+    last_state="$(cat "${state_file}")"
+  fi
+
+  if [[ "${percentage}" -le 10 && "${last_state}" != "low" ]]; then
+    notify-send -u critical "Battery low (${percentage}%)" "Please plug in the charger."
+    echo "low" > "${state_file}"
+  elif [[ "${percentage}" -gt 10 && -n "${last_state}" ]]; then
+    rm -f "${state_file}"
+  fi
+
+  sleep 60
+done


### PR DESCRIPTION
## Changes
- enable `services.upower` with low/critical/action thresholds (10/5/3) and `criticalPowerAction = "PowerOff"`
- add a user systemd service to notify on low battery via `notify-send`
- add `libnotify` to provide `notify-send`

## Risks / Impact
- Power: system will power off when battery reaches 3% (UPower action)
- Notifications: low-battery alert depends on user session + `mako`/`notify-send`

## Notes
- NixOS options referenced from `nixos/modules/services/hardware/upower.nix` (`services.upower.*`).