### PR TITLE
codex/issue-20-teams-camera-mic

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -180,7 +180,9 @@
     description = "ms";
     shell = pkgs.zsh;
     extraGroups = [
+      "audio"
       "networkmanager"
+      "video"
       "wheel"
       "input"
     ];

--- a/home/home.nix
+++ b/home/home.nix
@@ -42,6 +42,7 @@
     imagemagick
     file
     pavucontrol # audio settings
+    teams-for-linux
     signal-desktop
     nodejs
     wdisplays # screen management for wayland


### PR DESCRIPTION
## Changes
- add `pkgs.teams-for-linux` to `home.packages`
- add `audio` and `video` to `users.users.ms.extraGroups` for mic/cam access

## Risks / Impact
- Audio/Video: user is added to `audio`/`video` groups (system-wide permissions)

## Docs
- Home Manager option `home.packages` (home-manager `modules/home-environment.nix`)
- NixOS option `users.users.<name>.extraGroups` (nixpkgs `nixos/modules/config/users-groups.nix`)
- Package definition `pkgs/teams-for-linux` (nixpkgs `pkgs/by-name/te/teams-for-linux/package.nix`)