### PR TITLE
codex/numlock-sway

### DIFF
--- a/home/sway.nix
+++ b/home/sway.nix
@@ -33,6 +33,9 @@ in
         "type:touchpad" = {
           events = "disabled";
         };
+        "type:keyboard" = {
+          xkb_numlock = "enabled";
+        };
       };
       modifier = "Mod4";
       terminal = "alacritty";


### PR DESCRIPTION
## Was geändert wurde
- NumLock für alle Tastaturen in der Sway-Input-Konfiguration aktiviert (xkb_numlock = "enabled").

## Risiko-Bereiche
- Keine (nur Sway-Input-Setting, keine Boot/FS/GPU-Änderungen).

## flake.lock
- Nicht geändert.