### PR TITLE
codex/chrome-wayland

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -64,6 +64,7 @@
     GOPATH = "${config.home.homeDirectory}/go";
     GOBIN = "${config.home.sessionVariables.GOPATH}/bin";
     XDG_CACHE_HOME = "${config.home.homeDirectory}/.cache";
+    NIXOS_OZONE_WL = "1"; # run Chromium/Chrome on Wayland for smoother input + wtype support
 
   };
 


### PR DESCRIPTION
## Changes
- set `NIXOS_OZONE_WL=1` in the user session so Google Chrome/Chromium uses Wayland wrappers
- note intent in comment (smooth input and `wtype` shortcuts)

## Risks / Notes
- affects Chrome/Chromium startup flags only; requires restart of the browser to take effect
- no `flake.lock` or system-critical components touched
