### PR TITLE
codex/mic-mute-toggle

### DIFF
--- a/home/sway.nix
+++ b/home/sway.nix
@@ -134,6 +134,7 @@ in
         #############################
         # Audio
         "XF86AudioMute" = "exec wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+        "XF86AudioMicMute" = "exec wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle";
         "XF86AudioLowerVolume" = "exec wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-";
         "XF86AudioRaiseVolume" = "exec wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+";
 

--- a/shortcuts.md
+++ b/shortcuts.md
@@ -53,3 +53,4 @@ Modifikator: Mod4 (Super/Windows)
 | XF86AudioRaiseVolume | Lautstaerke erhoehen | Erhoeht die Lautstaerke aller erkannten Sinks um 5 Prozent. |
 | XF86AudioLowerVolume | Lautstaerke senken | Verringert die Lautstaerke aller erkannten Sinks um 5 Prozent. |
 | XF86AudioMute | Mute umschalten | Schaltet Mute fuer alle erkannten Sinks um. |
+| XF86AudioMicMute | Mikrofon stummschalten | Schaltet Mute fuer die Standard-Quelle um. |


### PR DESCRIPTION
## Was geaendert wurde
- Sway-Keybinding fuer `XF86AudioMicMute` hinzugefuegt (wpctl toggle auf Default-Quelle)
- Shortcut-Doku ergaenzt

## Risiko-Bereiche
- Audio/Input (Mikrofon-Mute via PipeWire)

## Hinweise
- `flake.lock` unveraendert