### PR TITLE
codex/mbsync-passcmd

### DIFF
--- a/home/mutt.nix
+++ b/home/mutt.nix
@@ -62,10 +62,7 @@
       passwordCommand = [
         "bash"
         "-lc"
-        ''
-          source "$HOME/.config/zsh/env.secrets"
-          printf %s "$GMX_MAIL_PASSWD"
-        ''
+        "source \"$HOME/.config/zsh/env.secrets\"; printf %s \"$GMX_MAIL_PASSWD\""
       ];
       imap = {
         host = "imap.gmx.net";


### PR DESCRIPTION
## Summary
- render `passwordCommand` as a single-line `PassCmd` so mbsync parses it correctly
- keep existing secrets sourcing behavior intact

## Risks
- Low; only affects mbsync password command parsing

## Notes
- `flake.lock` unchanged